### PR TITLE
Fix articles not refreshing due to aggressive Next.js caching

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,12 +5,16 @@ import ArticleList from './components/ArticleList'
 
 async function fetchHackerNewsTop(): Promise<Article[]> {
   try {
-    const topStoriesRes = await fetch('https://hacker-news.firebaseio.com/v0/topstories.json')
+    const topStoriesRes = await fetch('https://hacker-news.firebaseio.com/v0/topstories.json', {
+      next: { revalidate: 3600 } // Revalidate every hour
+    })
     const topStoryIds = await topStoriesRes.json()
     
     const stories = await Promise.all(
       topStoryIds.slice(0, 15).map(async (id: number) => {
-        const storyRes = await fetch(`https://hacker-news.firebaseio.com/v0/item/${id}.json`)
+        const storyRes = await fetch(`https://hacker-news.firebaseio.com/v0/item/${id}.json`, {
+          next: { revalidate: 3600 } // Revalidate every hour
+        })
         return storyRes.json()
       })
     )
@@ -47,7 +51,8 @@ async function fetchRedditTop(): Promise<Article[]> {
           const res = await fetch(`https://www.reddit.com/r/${subreddit}/top.json?limit=5&t=day`, {
             headers: {
               'User-Agent': 'CodeCurrent/1.0'
-            }
+            },
+            next: { revalidate: 3600 } // Revalidate every hour
           })
           const data = await res.json()
           return data.data.children.map((child: { data: RedditPost }) => child.data)


### PR DESCRIPTION
## Summary
- Fixed issue where articles weren't refreshing due to Next.js default caching behavior
- Added 1-hour cache revalidation (`next: { revalidate: 3600 }`) to all fetch requests
- Articles now update every hour while maintaining performance benefits of caching

## Changes Made
- **Modified `app/page.tsx`**: Added revalidation configuration to:
  - Hacker News top stories API call
  - Individual Hacker News story fetches  
  - Reddit subreddit API calls

## Technical Details
- **Before**: Fetch requests cached indefinitely (Next.js default behavior)
- **After**: Cache expires after 1 hour, allowing fresh content while reducing API calls
- **Build output confirms**: Route shows "Revalidate 1h" in build stats

## Testing
- ✅ Build passes successfully
- ✅ Linting passes with no errors
- ✅ Playwright verification shows articles loading correctly
- ✅ Application displays fresh content from both Hacker News and Reddit

## Impact
- **User Experience**: Articles refresh every hour instead of requiring app redeployment
- **Performance**: Maintains caching benefits while ensuring content freshness
- **API Usage**: Balanced approach - not too aggressive, not too stale

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)