### PR TITLE
feat(add-tab-navigation): Add source-based article filtering with tab navigation

### DIFF
--- a/app/components/TabNavigation.tsx
+++ b/app/components/TabNavigation.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link'
+
+interface TabNavigationProps {
+  activeTab: 'all' | 'hackernews' | 'reddit'
+}
+
+export default function TabNavigation({ activeTab }: TabNavigationProps) {
+  const tabs = [
+    { id: 'all' as const, label: 'All', href: '/' },
+    { id: 'hackernews' as const, label: 'Hacker News', href: '/?tab=hackernews' },
+    { id: 'reddit' as const, label: 'Reddit', href: '/?tab=reddit' }
+  ]
+
+  return (
+    <div className="bg-white py-3">
+      <div className="max-w-4xl mx-auto px-4 md:px-8">
+        <nav className="flex space-x-2">
+          {tabs.map((tab) => (
+            <Link
+              key={tab.id}
+              href={tab.href}
+              className={`px-2 py-1 rounded-full text-xs font-medium transition-colors min-w-[80px] text-center ${
+                activeTab === tab.id
+                  ? 'text-white'
+                  : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
+              }`}
+              style={activeTab === tab.id ? (
+                tab.id === 'hackernews' ? { backgroundColor: '#FF6600' } :
+                tab.id === 'reddit' ? { backgroundColor: '#FF4500' } :
+                { backgroundColor: '#000000' }
+              ) : {}}
+            >
+              {tab.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,23 @@
 import { Suspense } from 'react'
 import { Article } from '@/lib/types'
 import ArticleList from './components/ArticleList'
+import TabNavigation from './components/TabNavigation'
 import { getHackerNewsTop } from './queries/getHackerNewsTop'
 import { getRedditTop } from './queries/getRedditTop'
 import { calculateNormalizedScore } from './utils/scoring'
 
-async function fetchAllArticles(): Promise<Article[]> {
+async function fetchArticles(tab: 'all' | 'hackernews' | 'reddit'): Promise<Article[]> {
+  if (tab === 'hackernews') {
+    const articles = await getHackerNewsTop()
+    return articles.slice(0, 20)
+  }
+  
+  if (tab === 'reddit') {
+    const articles = await getRedditTop()
+    return articles.slice(0, 20)
+  }
+  
+  // tab === 'all'
   const [hackerNewsArticles, redditArticles] = await Promise.all([
     getHackerNewsTop(),
     getRedditTop()
@@ -17,23 +29,33 @@ async function fetchAllArticles(): Promise<Article[]> {
   return allArticles.sort((a, b) => calculateNormalizedScore(b) - calculateNormalizedScore(a)).slice(0, 20)
 }
 
-export default async function Home() {
+interface HomeProps {
+  searchParams: { tab?: string }
+}
+
+export default async function Home({ searchParams }: HomeProps) {
+  const tab = (searchParams.tab === 'hackernews' || searchParams.tab === 'reddit') 
+    ? searchParams.tab 
+    : 'all'
+  
   return (
-    <div className="max-w-4xl mx-auto px-4 md:px-8 pb-8">
-      
-      <Suspense fallback={
-        <div className="space-y-6">
-          {Array.from({ length: 20 }).map((_, i) => (
-            <div key={i} className="animate-pulse">
-              <div className="h-6 bg-gray-200 rounded mb-2"></div>
-              <div className="h-4 bg-gray-100 rounded mb-2"></div>
-              <div className="h-3 bg-gray-100 rounded w-1/3"></div>
-            </div>
-          ))}
-        </div>
-      }>
-        <ArticleList articles={await fetchAllArticles()} />
-      </Suspense>
-    </div>
+    <>
+      <TabNavigation activeTab={tab} />
+      <div className="max-w-4xl mx-auto px-4 md:px-8 pb-8">
+        <Suspense fallback={
+          <div className="space-y-6">
+            {Array.from({ length: 20 }).map((_, i) => (
+              <div key={i} className="animate-pulse">
+                <div className="h-6 bg-gray-200 rounded mb-2"></div>
+                <div className="h-4 bg-gray-100 rounded mb-2"></div>
+                <div className="h-3 bg-gray-100 rounded w-1/3"></div>
+              </div>
+            ))}
+          </div>
+        }>
+          <ArticleList articles={await fetchArticles(tab)} />
+        </Suspense>
+      </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- Add TabNavigation component with All/Hacker News/Reddit tabs
- Implement server-side filtering using URL searchParams
- Use source-specific colors matching article source badges

## Changes
- **TabNavigation Component**: Server-side tab navigation with clean URL routing
- **Article Filtering**: Filter articles by source (all/hackernews/reddit) 
- **Visual Design**: Rounded button style with brand colors (HN orange, Reddit orange-red)
- **State Management**: URL-based state using Next.js searchParams

## Test Plan
- [ ] Verify all three tabs work correctly
- [ ] Test URL routing (/, /?tab=hackernews, /?tab=reddit)
- [ ] Confirm proper article filtering per tab
- [ ] Check visual styling matches article source badges
- [ ] Ensure responsive design works on mobile/desktop

🤖 Generated with [Claude Code](https://claude.ai/code)