### PR TITLE
fix(article-border-spacing): Fix missing border for first article without thumbnail

### DIFF
--- a/app/components/ArticleList.tsx
+++ b/app/components/ArticleList.tsx
@@ -23,7 +23,7 @@ export default function ArticleList({ articles }: ArticleListProps) {
       {firstArticle.thumbnail ? (
         <FeaturedArticleCard article={firstArticle} />
       ) : (
-        <div className="space-y-0">
+        <div className="[&>article]:!border-b [&>article]:!border-gray-100">
           <ArticleCard article={firstArticle} />
         </div>
       )}


### PR DESCRIPTION
## Summary
- Fix missing bottom border when first article has no thumbnail
- Ensure consistent visual separation between articles

## Problem
When the first article doesn't have a thumbnail, it's displayed as a regular ArticleCard but lacks a bottom border due to the `last:border-b-0` CSS class removing borders from isolated elements.

## Solution
- Use Tailwind's arbitrary selector to force border display
- Override the `last:border-b-0` class with `\!important` modifier
- Maintain existing spacing and layout logic

## Test Plan
- [ ] Verify border appears when first article has no thumbnail
- [ ] Confirm border maintains full width without gaps
- [ ] Check that content spacing remains consistent
- [ ] Test on both mobile and desktop layouts

🤖 Generated with [Claude Code](https://claude.ai/code)